### PR TITLE
Fix typo in license section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ Issues and small PRs are welcome. Please keep changes focused and self‑contain
 
 ## License
 
-Mages is licensed under the **GNU AGPL v3** (see `LICENSE`), with all the artwork, logos, and visual assets are licensed under a [CCA-BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).
+Mages is licensed under the **GNU AGPL v3** (see `LICENSE`), with all the artwork, logos, and visual assets are licensed under a [CC BY-SA 4.0 License](https://creativecommons.org/licenses/by-sa/4.0/).


### PR DESCRIPTION
This fixes a typo in the README.md regarding the license used for artwork, logos, and visual assets.